### PR TITLE
Add GUI app for voice-based OMOP query generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ python speech_to_omop.py path/to/audio_file.wav
 The script prints a SQL query. The output assumes the target database implements
 the OMOP Common Data Model and is intended as a starting point that may require
 validation before execution.
+
+### GUI application
+
+For an interactive application that records audio from your microphone, run:
+
+```
+python app.py
+```
+
+A small window will open. Click **Start**, speak your query, and the resulting
+OMOP SQL will be displayed.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,81 @@
+"""Simple GUI application to convert speech into an OMOP SQL query."""
+
+import os
+import tempfile
+import wave
+from typing import Optional
+
+import sounddevice as sd
+import openai
+import tkinter as tk
+from tkinter import messagebox
+
+from speech_to_omop import speech_to_omop_query
+
+
+def record_audio(seconds: int = 5, samplerate: int = 16000) -> str:
+    """Record audio from the system microphone and save to a temporary WAV file.
+
+    Parameters
+    ----------
+    seconds: int
+        Duration to record.
+    samplerate: int
+        Sampling rate in Hertz.
+
+    Returns
+    -------
+    str
+        Path to the temporary WAV file containing the recording.
+    """
+    recording = sd.rec(int(seconds * samplerate), samplerate=samplerate, channels=1, dtype="int16")
+    sd.wait()
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    with wave.open(tmp.name, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)  # 16-bit audio
+        wf.setframerate(samplerate)
+        wf.writeframes(recording.tobytes())
+    return tmp.name
+
+
+def start_recording() -> None:
+    """Record audio, convert to an OMOP query, and display the result."""
+    label.config(text="Recording... Please speak now.")
+    root.update()
+    audio_file = record_audio()
+    try:
+        query = speech_to_omop_query(audio_file)
+    finally:
+        try:
+            os.unlink(audio_file)
+        except OSError:
+            pass
+    label.config(text="OMOP SQL query:")
+    text_box.delete("1.0", tk.END)
+    text_box.insert(tk.END, query)
+
+
+# Ensure API key is available
+api_key: Optional[str] = os.environ.get("OPENAI_API_KEY")
+if not api_key:
+    messagebox.showerror("Missing API Key", "Please set the OPENAI_API_KEY environment variable.")
+    raise SystemExit(1)
+openai.api_key = api_key
+
+# Build simple GUI
+root = tk.Tk()
+root.title("Speech to OMOP Query")
+root.geometry("600x400")
+
+label = tk.Label(root, text="Click 'Start' and speak your query")
+label.pack(pady=10)
+
+start_button = tk.Button(root, text="Start", command=start_recording)
+start_button.pack(pady=5)
+
+text_box = tk.Text(root, wrap="word")
+text_box.pack(expand=True, fill="both", padx=10, pady=10)
+
+root.mainloop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openai>=0.28
+sounddevice>=0.4


### PR DESCRIPTION
## Summary
- introduce a Tkinter GUI that records microphone input, transcribes it, and renders an OMOP SQL query
- document new GUI workflow and add sounddevice dependency

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`
- `python -m py_compile app.py speech_to_omop.py`


------
https://chatgpt.com/codex/tasks/task_e_68af5f9a44588321ad397f5f70319e56